### PR TITLE
Videresender hjemmesiden til swagger

### DIFF
--- a/NinKode.WebApi/Helpers/Swagger/SwaggerConfiguration.cs
+++ b/NinKode.WebApi/Helpers/Swagger/SwaggerConfiguration.cs
@@ -23,6 +23,15 @@ public static class SwaggerConfiguration
 
         app.UseSwaggerUI(options =>
         {
+            //turn of syntaxhighlight in swagger for better responsetime
+            if (app.Environment.IsDevelopment() || app.Environment.IsStaging())
+            {
+                options.ConfigObject.AdditionalItems["syntaxHighlight"] = new Dictionary<string, object>
+                {
+                    ["activated"] = false
+                };
+            }
+
             var descriptions = versionDescriptionProvider.ApiVersionDescriptions.Reverse().ToList();
 
             foreach (var description in descriptions)
@@ -31,7 +40,6 @@ public static class SwaggerConfiguration
                     description.GroupName.ToUpperInvariant());
             }
 
-            options.RoutePrefix = string.Empty;
             options.DisplayRequestDuration();
         });
     }

--- a/NinKode.WebApi/Startup.cs
+++ b/NinKode.WebApi/Startup.cs
@@ -62,15 +62,8 @@ builder.Services.AddProblemDetails(options => { options.IncludeExceptionDetails 
 
 var app = builder.Build();
 
-//turn of syntaxhighlight in swagger for better responsetime
-if (app.Environment.IsDevelopment() || app.Environment.IsStaging())
-{
-    app.UseSwagger();
-    app.UseSwaggerUI(config => config.ConfigObject.AdditionalItems["syntaxHighlight"] = new Dictionary<string, object>
-    {
-        ["activated"] = false
-    });
-}
+// redirect homepage to swagger ui
+app.MapGet("/", (HttpContext context) => context.Response.Redirect("./swagger/index.html", permanent: true));
 
 app.MapControllers();
 


### PR DESCRIPTION
Videresender hjemmesiden til swagger og bruker samme url som det eksisterende api'et (/swagger/index.html) - etter en liten diskusjon med @Myrdrahl 

Det vil da gjøre at http://localhost:5000/ videresender til http://localhost:5000/swagger/index.html, og at den originale url'en beholdes (https://nin-kode-api.artsdatabanken.no/swagger/index.html)

Flyttet koden for "turn of syntaxhighlight in swagger for better responsetime", siden den gjorde at app.UseSwagger og app.UseSwaggerUI ble gjort dobbelt - og var litt vanskelig å vite hvilke innstillinger som ble brukt. Er også litt usikker om denne optimaliseringen kun skal gjøres i lokalt miljø og på staging - og ikke i produksjon?