### PR TITLE
update search category and use LINQ

### DIFF
--- a/NiN3.Infrastructure/Services/SearchService.cs
+++ b/NiN3.Infrastructure/Services/SearchService.cs
@@ -26,44 +26,100 @@ namespace NiN3.Infrastructure.Services
                 case KlasseEnum.T:
                     // Implementation logic for Value1
                     // SQL query to retrieve data from the database using the NiN3DbContext
-                    var queryT = "SELECT Klasse, Kode, Langkode, Navn FROM AlleLangkoderView WHERE Klasse = 'Type' AND Navn COLLATE NOCASE LIKE @searchTerm";
-                    resultlist = _context.Set<Core.Models.SearchResult>().FromSqlRaw(queryT, new SqliteParameter("@searchTerm", searchTermQ)).ToList();
- 
+                    resultlist = _context.AlleLangkoderView
+                        .Where(x => x.Klasse == "Type" && EF.Functions.Like(x.Navn, $"{searchTermQ}"))
+                        .Select(x => new SearchResult
+                        {
+                            Klasse = x.Klasse,
+                            Kode = x.Kode,
+                            Langkode = x.Langkode,
+                            Navn = x.Navn
+                        }).ToList();
                     break;
                 case KlasseEnum.HTG:
                     // Implementation logic for Value2
-                    var queryHTG = "SELECT Klasse, Kode, Langkode, Navn FROM AlleLangkoderView WHERE Klasse = 'Hovedtypegruppe' AND Navn COLLATE NOCASE LIKE @searchTerm";
-                    resultlist = _context.Set<Core.Models.SearchResult>().FromSqlRaw(queryHTG, new SqliteParameter("@searchTerm", searchTermQ)).ToList();
+                    resultlist = _context.AlleLangkoderView
+                        .Where(x => x.Klasse == "Hovedtypegruppe" && EF.Functions.Like(x.Navn, $"{searchTermQ}"))
+                        .Select(x => new SearchResult
+                        {
+                            Klasse = x.Klasse,
+                            Kode = x.Kode,
+                            Langkode = x.Langkode,
+                            Navn = x.Navn
+                        }).ToList();
                     break;
                 case KlasseEnum.HT:
                     // Implementation logic for Value3
-                    var queryHT = "SELECT Klasse, Kode, Langkode, Navn FROM AlleLangkoderView WHERE Klasse = 'Hovedtype' AND Navn COLLATE NOCASE LIKE @searchTerm";
-                    resultlist = _context.Set<Core.Models.SearchResult>().FromSqlRaw(queryHT, new SqliteParameter("@searchTerm", searchTermQ)).ToList();
+                    resultlist = _context.AlleLangkoderView
+                        .Where(x => x.Klasse == "Hovedtype" && EF.Functions.Like(x.Navn, $"{searchTermQ}"))
+                        .Select(x => new SearchResult
+                        {
+                            Klasse = x.Klasse,
+                            Kode = x.Kode,
+                            Langkode = x.Langkode,
+                            Navn = x.Navn
+                        }).ToList();
                     break;
                 case KlasseEnum.GT:
                     // Implementation logic for Value3
-                    var queryGT = "SELECT Klasse, Kode, Langkode, Navn FROM AlleLangkoderView WHERE Klasse = 'Grunntype' AND Navn COLLATE NOCASE LIKE @searchTerm";
-                    resultlist = _context.Set<Core.Models.SearchResult>().FromSqlRaw(queryGT, new SqliteParameter("@searchTerm", searchTermQ)).ToList();
+                    resultlist = _context.AlleLangkoderView
+                        .Where(x => x.Klasse == "Grunntype" && EF.Functions.Like(x.Navn, $"{searchTermQ}"))
+                        .Select(x => new SearchResult
+                        {
+                            Klasse = x.Klasse,
+                            Kode = x.Kode,
+                            Langkode = x.Langkode,
+                            Navn = x.Navn
+                        }).ToList();
                     break;
                 case KlasseEnum.V:
                     // Implementation logic for Value3
-                    var queryV = "SELECT Klasse, Kode, Langkode, Navn FROM AlleLangkoderView WHERE Klasse = 'V' AND Navn COLLATE NOCASE LIKE @searchTerm";
-                    resultlist = _context.Set<Core.Models.SearchResult>().FromSqlRaw(queryV, new SqliteParameter("@searchTerm", searchTermQ)).ToList();
+                    resultlist = _context.AlleLangkoderView
+                        .Where(x => x.Klasse == "Variabel" && EF.Functions.Like(x.Navn, $"{searchTermQ}"))
+                        .Select(x => new SearchResult
+                        {
+                            Klasse = x.Klasse,
+                            Kode = x.Kode,
+                            Langkode = x.Langkode,
+                            Navn = x.Navn
+                        }).ToList();
                     break;
                 case KlasseEnum.VN:
                     // Implementation logic for Value3
-                    var queryVN = "SELECT Klasse, Kode, Langkode, Navn FROM AlleLangkoderView WHERE Klasse = 'VN' AND Navn COLLATE NOCASE LIKE @searchTerm";
-                    resultlist = _context.Set<Core.Models.SearchResult>().FromSqlRaw(queryVN, new SqliteParameter("@searchTerm", searchTermQ)).ToList();
+                    resultlist = _context.AlleLangkoderView
+                        .Where(x => x.Klasse == "Variabelnavn" && EF.Functions.Like(x.Navn, $"{searchTermQ}"))
+                        .Select(x => new SearchResult
+                        {
+                            Klasse = x.Klasse,
+                            Kode = x.Kode,
+                            Langkode = x.Langkode,
+                            Navn = x.Navn
+                        }).ToList();
                     break;
                 case KlasseEnum.KE:
                     // Add more cases for all possible values of KlasseEnum
-                    var queryKE = "SELECT Klasse, Kode, Langkode, Navn FROM AlleLangkoderView WHERE Klasse = 'KE' AND Navn COLLATE NOCASE LIKE @searchTerm";
-                    resultlist = _context.Set<Core.Models.SearchResult>().FromSqlRaw(queryKE, new SqliteParameter("@searchTerm", searchTermQ)).ToList();
+                    resultlist = _context.AlleLangkoderView
+                        .Where(x => x.Klasse == "Kartleggingsenhet" && EF.Functions.Like(x.Navn, $"{searchTermQ}"))
+                        .Select(x => new SearchResult
+                        {
+                            Klasse = x.Klasse,
+                            Kode = x.Kode,
+                            Langkode = x.Langkode,
+                            Navn = x.Navn
+                        })
+                        .ToList();
                     break;
                 case KlasseEnum.ALL:
                     // Implementation logic for Value3
-                    var queryALL = "SELECT Klasse, Kode, Langkode, Navn FROM AlleLangkoderView WHERE Navn COLLATE NOCASE LIKE @searchTerm";
-                    resultlist = _context.Set<Core.Models.SearchResult>().FromSqlRaw(queryALL, new SqliteParameter("@searchTerm", searchTermQ)).ToList();
+                    resultlist = _context.AlleLangkoderView
+                        .Where(x => EF.Functions.Like(x.Navn, $"{searchTermQ}"))
+                        .Select(x => new SearchResult
+                        {
+                            Klasse = x.Klasse,
+                            Kode = x.Kode,
+                            Langkode = x.Langkode,
+                            Navn = x.Navn
+                        }).ToList();
                     break;
                 default:
                     // Default implementation logic

--- a/NiN3.Infrastructure/Services/SearchService.cs
+++ b/NiN3.Infrastructure/Services/SearchService.cs
@@ -25,7 +25,6 @@ namespace NiN3.Infrastructure.Services
             {
                 case KlasseEnum.T:
                     // Implementation logic for Value1
-                    // SQL query to retrieve data from the database using the NiN3DbContext
                     resultlist = _context.AlleLangkoderView
                         .Where(x => x.Klasse == "Type" && EF.Functions.Like(x.Navn, $"{searchTermQ}"))
                         .Select(x => new SearchResult
@@ -108,6 +107,17 @@ namespace NiN3.Infrastructure.Services
                             Navn = x.Navn
                         })
                         .ToList();
+                    break;
+                case KlasseEnum.VT:
+                    resultlist = _context.AlleLangkoderView
+                        .Where(x => x.Klasse == "Variabeltrinn" && EF.Functions.Like(x.Navn, $"{searchTermQ}"))
+                        .Select(x => new SearchResult
+                        {
+                            Klasse = x.Klasse,
+                            Kode = x.Kode,
+                            Langkode = x.Langkode,
+                            Navn = x.Navn
+                        }).ToList();
                     break;
                 case KlasseEnum.ALL:
                     // Implementation logic for Value3

--- a/NiN3.Tests/Infrastructure/SearchServiceTest.cs
+++ b/NiN3.Tests/Infrastructure/SearchServiceTest.cs
@@ -54,5 +54,23 @@ namespace NiN3.Tests.Infrastructure
             var result2 = service.SimpleSearch("limnisk", KlasseEnum.ALL, SearchMethodEnum.C);
             Assert.Equal(7, result2.Count);
         }
+
+        [Theory]
+        [InlineData(KlasseEnum.T, 0)]
+        [InlineData(KlasseEnum.HTG, 3)]
+        [InlineData(KlasseEnum.HT, 27)]
+        [InlineData(KlasseEnum.GT, 42)]
+        [InlineData(KlasseEnum.KE, 55)]
+        [InlineData(KlasseEnum.V, 0)]
+        [InlineData(KlasseEnum.VN, 2)]
+        [InlineData(KlasseEnum.VT, 0)]
+        [InlineData(KlasseEnum.ALL, 129)]
+        public void SimpleSearchExpectedResultsTest(KlasseEnum klasseEnum, int expectedResults)
+        {
+            var service = GetPrepearedSearchService();
+            var resultContainsMyrT = service.SimpleSearch("myr", klasseEnum, SearchMethodEnum.C);
+            Assert.Equal(expectedResults, resultContainsMyrT.Count);
+        }
+
     }
 }


### PR DESCRIPTION
Close #139 

Fixed search for KE, VN and V.
Using Linq expressions instead of query string.